### PR TITLE
chore: Remove refmaps

### DIFF
--- a/src/main/resources/pmmo_farmers_compat.mixins.json
+++ b/src/main/resources/pmmo_farmers_compat.mixins.json
@@ -2,7 +2,6 @@
   "required": true,
   "minVersion": "0.7",
   "package": "net.silvertide.pmmo_farmers_compat.mixin",
-  "refmap": "pmmo_farmers_compat.refmap.json",
   "compatibilityLevel": "JAVA_21",
   "mixins": [
     "CookingPotProcessCookingMixin",


### PR DESCRIPTION
NeoForge don't need refmaps and it only causes warning in the logs.